### PR TITLE
Require lower version of `collection` compatible with flutter

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  collection: ^1.18.0
+  collection: ^1.17.2
   flutter:
     sdk: flutter
   


### PR DESCRIPTION
Relax the version constraint of `collection` to be compatible with flutter.

The `1.18` version was adding some new features to `CanonicalizedMap`, but as this library doesn't use them it should be fine.

Fixes #1 